### PR TITLE
[ACS] aks create/update: add --vnet-subnet_id validation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -52,6 +52,8 @@ def get_auth_management_client(cli_ctx, scope=None, **_):
         matched = re.match('/subscriptions/(?P<subscription>[^/]*)/', scope)
         if matched:
             subscription_id = matched.groupdict()['subscription']
+        else:
+            raise CLIError("{} does not contain subscription Id.".format(scope))
     return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_AUTHORIZATION, subscription_id=subscription_id)
 
 

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -20,7 +20,7 @@ from ._validators import (
     validate_create_parameters, validate_k8s_client_version, validate_k8s_version, validate_linux_host_name,
     validate_list_of_integers, validate_ssh_key, validate_connector_name, validate_max_pods, validate_nodes_count,
     validate_nodepool_name, validate_vm_set_type, validate_load_balancer_sku, validate_load_balancer_outbound_ips,
-    validate_load_balancer_outbound_ip_prefixes, validate_taints, validate_ip_ranges, validate_acr)
+    validate_load_balancer_outbound_ip_prefixes, validate_taints, validate_ip_ranges, validate_acr, validate_vnet_subnet_id)
 
 aci_connector_os_type = ['Windows', 'Linux', 'Both']
 
@@ -190,7 +190,7 @@ def load_arguments(self, _):
         c.argument('no_ssh_key', options_list=['--no-ssh-key', '-x'])
         c.argument('pod_cidr')
         c.argument('service_cidr')
-        c.argument('vnet_subnet_id')
+        c.argument('vnet_subnet_id', type=str, validator=validate_vnet_subnet_id)
         c.argument('workspace_resource_id')
         c.argument('skip_subnet_role_assignment', action='store_true')
         c.argument('api_server_authorized_ip_ranges', type=str, validator=validate_ip_ranges)

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -224,3 +224,8 @@ def validate_taints(namespace):
 def validate_acr(namespace):
     if namespace.attach_acr and namespace.detach_acr:
         raise CLIError('Cannot specify "--attach-acr" and "--detach-acr" at the same time.')
+
+def validate_vnet_subnet_id(namespace):
+    from msrestazure.tools import is_valid_resource_id
+    if not is_valid_resource_id(namespace.vnet_subnet_id):
+        raise CLIError("--vnet-subnet-id is not a valid Azure resource ID.")

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -226,6 +226,9 @@ def validate_acr(namespace):
         raise CLIError('Cannot specify "--attach-acr" and "--detach-acr" at the same time.')
 
 def validate_vnet_subnet_id(namespace):
-    from msrestazure.tools import is_valid_resource_id
-    if not is_valid_resource_id(namespace.vnet_subnet_id):
-        raise CLIError("--vnet-subnet-id is not a valid Azure resource ID.")
+    if namespace.vnet_subnet_id is not None:
+        if namespace.vnet_subnet_id == '':
+            return
+        from msrestazure.tools import is_valid_resource_id
+        if not is_valid_resource_id(namespace.vnet_subnet_id):
+            raise CLIError("--vnet-subnet-id is not a valid Azure resource ID.")

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -79,6 +79,17 @@ class TestVNetSubnetId(unittest.TestCase):
         invalid_vnet_subnet_id = "/subscriptions/testid/resourceGroups/MockedResourceGroup/providers/Microsoft.Network/virtualNetworks/MockedNetworkId/subnets/MockedSubNetId"
         namespace = VnetSubnetIdNamespace(invalid_vnet_subnet_id)
         validators.validate_vnet_subnet_id(namespace)
+    
+    def test_none_vnet_subnet_id(self):
+        invalid_vnet_subnet_id = None
+        namespace = VnetSubnetIdNamespace(invalid_vnet_subnet_id)
+        validators.validate_vnet_subnet_id(namespace)
+    
+    def test_empty_vnet_subnet_id(self):
+        invalid_vnet_subnet_id = ""
+        namespace = VnetSubnetIdNamespace(invalid_vnet_subnet_id)
+        validators.validate_vnet_subnet_id(namespace)
+
 
 class VnetSubnetIdNamespace:
     def __init__(self, vnet_subnet_id):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -64,3 +64,22 @@ class TestValidateIPRanges(unittest.TestCase):
 class Namespace:
     def __init__(self, api_server_authorized_ip_ranges):
         self.api_server_authorized_ip_ranges = api_server_authorized_ip_ranges
+
+class TestVNetSubnetId(unittest.TestCase):
+    def test_invalid_vnet_subnet_id(self):
+        invalid_vnet_subnet_id = "dummy subnet id"
+        namespace = VnetSubnetIdNamespace(invalid_vnet_subnet_id)
+        err = ("--vnet-subnet-id is not a valid Azure resource ID.")
+
+        with self.assertRaises(CLIError) as cm:
+            validators.validate_vnet_subnet_id(namespace)
+        self.assertEqual(str(cm.exception), err)
+
+    def test_valid_vnet_subnet_id(self):
+        invalid_vnet_subnet_id = "/subscriptions/testid/resourceGroups/MockedResourceGroup/providers/Microsoft.Network/virtualNetworks/MockedNetworkId/subnets/MockedSubNetId"
+        namespace = VnetSubnetIdNamespace(invalid_vnet_subnet_id)
+        validators.validate_vnet_subnet_id(namespace)
+
+class VnetSubnetIdNamespace:
+    def __init__(self, vnet_subnet_id):
+        self.vnet_subnet_id = vnet_subnet_id


### PR DESCRIPTION
This checklist is used to make sure that common guidelines for a pull request are followed.

- [ X] The PR title and description have followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

Test Done:
Unit Test Passed for new feature.
used following command, and get expected error.
az aks create -g qike_eastus --name eastus-cni --node-count 1 -s Standard_D1_v2 --ssh-key-value /Users/chenyizhang/.ssh/id_rsa.pub --network-plugin azure --max-pods 100 --vnet-subnet-id bogusssss